### PR TITLE
Include acipolicygen error message in exception

### DIFF
--- a/infra/generate_security_policy.py
+++ b/infra/generate_security_policy.py
@@ -32,10 +32,9 @@ def generate_security_policy(
         with open(arm_template_path, "w") as f:
             json.dump(arm_template, f, indent=2)
 
-        subprocess.run(
+        subprocess.check_output(
             f"az confcom acipolicygen -a {arm_template_path} --outraw > {security_policy_path}",
             shell=True,
-            check=True,
         )
 
         with open(security_policy_path, "rb") as f:


### PR DESCRIPTION
Using run with check=True only raises an exception if the command returns a non-zero error, use check_output instead so that the error includes the stdout of the command