### PR TITLE
Add option to build and replace HCSshim in containerplat

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -163,6 +163,8 @@
             "args": [
                 "--arm-template-path",
                 "examples/${input:testName}/${input:armTemplateName}",
+                "--hcsshim-url",
+                "${input:hcsShimUrl}",
             ]
         },
         {
@@ -234,6 +236,12 @@
             "id": "storageContainerName",
             "type": "promptString",
             "description": "Enter a name for the storage container:",
+        },
+        {
+            "id": "hcsShimUrl",
+            "type": "promptString",
+            "description": "Enter the URL of HCSShim to deploy:",
+            "default": "git@github.com:microsoft/hcsshim.git"
         },
     ]
 }

--- a/env
+++ b/env
@@ -27,6 +27,7 @@
 # DEPLOYMENT_NAME=your-deployment-name
 # Uses the given policy file instead of generating one (relative to examples/)
 # SECURITY_POLICY=simple_server/security_policies/allow_all.rego
+# HCSSHIM_URL=git@github.com:microsoft/hcsshim.git
 #
 # Sidecar Images ---------------------------------------------------------------
 # ATTESTATION_SIDECAR_IMAGE=http://confidentialsidecars.azurecr.io/attestation:main

--- a/infra/vm/build_hcsshim.py
+++ b/infra/vm/build_hcsshim.py
@@ -1,0 +1,41 @@
+import glob
+import os
+import shutil
+import subprocess
+import tempfile
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from infra.vm.get_containerplat import update_package
+
+
+def build_hcsshim(
+    package_path: str,
+    hcsshim_url: str,
+):
+    with tempfile.TemporaryDirectory() as hcsshim_dir:
+        with update_package(package_path) as package_dir:
+            os.chdir(hcsshim_dir)
+            subprocess.check_output(
+                f"git clone {hcsshim_url} github.com/Microsoft/hcsshim", shell=True
+            )
+            os.chdir("github.com/Microsoft/hcsshim")
+            os.environ["GOPATH"] = hcsshim_dir
+            os.environ["GOOS"] = "windows"
+            os.environ["GO_BUILD_FLAGS"] = "-tags=rego"
+            for target in [
+                "cmd/containerd-shim-runhcs-v1",
+                "cmd/device-util",
+                "cmd/jobobject-util",
+                "cmd/ncproxy",
+                "cmd/runhcs",
+                "cmd/shimdiag",
+                "internal/tools/grantvmgroupaccess",
+                "internal/tools/zapdir",
+            ]:
+                subprocess.check_output(
+                    f"go build github.com/Microsoft/hcsshim/{target}", shell=True
+                )
+            for file in glob.glob("*.exe"):
+                shutil.copy(file, package_dir)

--- a/infra/vm/build_hcsshim.py
+++ b/infra/vm/build_hcsshim.py
@@ -22,6 +22,8 @@ def build_hcsshim(
                 f"git clone {hcsshim_url} github.com/Microsoft/hcsshim", shell=True
             )
             os.chdir("github.com/Microsoft/hcsshim")
+
+            # Build Go targets
             os.environ["GOPATH"] = hcsshim_dir
             os.environ["GOOS"] = "windows"
             os.environ["GO_BUILD_FLAGS"] = "-tags=rego"
@@ -40,4 +42,19 @@ def build_hcsshim(
                 )
             for file in glob.glob("*.exe"):
                 shutil.copy(file, package_dir)
+
+            # Build Userspace
+            kernel_dir = "linux_kernel"
+            os.mkdir(kernel_dir)
+            subprocess.run(
+                f'az artifacts universal download --organization "https://dev.azure.com/msazure/" --project "dcf1de98-e135-4121-8a6c-99b73705f581" --scope project --feed "ContainerPlat-Dev" --name "enlightened-linux" --version "0.1.5" --path {kernel_dir}',
+                shell=True,
+            )
+            shutil.copy(
+                f"{kernel_dir}/core-image-minimal-aci-rootfs.tar", "base.tar.gz"
+            )
+            subprocess.run("make all && make rootfs", shell=True)
+            shutil.copy("out/initrd.img", f"{package_dir}/LinuxBootFiles/initrd.img")
+            shutil.copy("out/rootfs.vhd", f"{package_dir}/LinuxBootFiles/rootfs.vhd")
+
     prev_dir = os.chdir(prev_dir)

--- a/infra/vm/build_hcsshim.py
+++ b/infra/vm/build_hcsshim.py
@@ -7,7 +7,7 @@ import sys
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
-from infra.vm.get_containerplat import update_package
+from infra.vm.update_containerplat import update_package
 
 
 def build_hcsshim(

--- a/infra/vm/build_hcsshim.py
+++ b/infra/vm/build_hcsshim.py
@@ -14,6 +14,7 @@ def build_hcsshim(
     package_path: str,
     hcsshim_url: str,
 ):
+    prev_dir = os.getcwd()
     with tempfile.TemporaryDirectory() as hcsshim_dir:
         with update_package(package_path) as package_dir:
             os.chdir(hcsshim_dir)
@@ -39,3 +40,4 @@ def build_hcsshim(
                 )
             for file in glob.glob("*.exe"):
                 shutil.copy(file, package_dir)
+    prev_dir = os.chdir(prev_dir)

--- a/infra/vm/deploy_containerplat.py
+++ b/infra/vm/deploy_containerplat.py
@@ -74,6 +74,7 @@ def deploy_containerplat(
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--arm-template-path", required=True)
+    parser.add_argument("--hcsshim-url")
     args = parser.parse_args()
 
     with open(args.arm_template_path) as f:
@@ -91,7 +92,10 @@ if __name__ == "__main__":
             assert vm_ip
 
             with tempfile.TemporaryDirectory() as temp_dir:
-                get_containerplat(temp_dir)
+                get_containerplat(
+                    directory_path=temp_dir,
+                    hcsshim_url=args.hcsshim_url or None,
+                )
                 deploy_containerplat(
                     ip_address=vm_ip,
                     container_plat_path=temp_dir,

--- a/infra/vm/get_containerplat.py
+++ b/infra/vm/get_containerplat.py
@@ -1,43 +1,15 @@
 from contextlib import contextmanager
-import glob
 import os
-import shutil
 import subprocess
 import json
 import tempfile
 from typing import Optional
 import zipfile
+import sys
 
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
-def build_hcsshim(
-    package_path: str,
-    hcsshim_url: str,
-):
-    with tempfile.TemporaryDirectory() as hcsshim_dir:
-        with update_package(package_path) as package_dir:
-            os.chdir(hcsshim_dir)
-            subprocess.check_output(
-                f"git clone {hcsshim_url} github.com/Microsoft/hcsshim", shell=True
-            )
-            os.chdir("github.com/Microsoft/hcsshim")
-            os.environ["GOPATH"] = hcsshim_dir
-            os.environ["GOOS"] = "windows"
-            os.environ["GO_BUILD_FLAGS"] = "-tags=rego"
-            for target in [
-                "cmd/containerd-shim-runhcs-v1",
-                "cmd/device-util",
-                "cmd/jobobject-util",
-                "cmd/ncproxy",
-                "cmd/runhcs",
-                "cmd/shimdiag",
-                "internal/tools/grantvmgroupaccess",
-                "internal/tools/zapdir",
-            ]:
-                subprocess.check_output(
-                    f"go build github.com/Microsoft/hcsshim/{target}", shell=True
-                )
-            for file in glob.glob("*.exe"):
-                shutil.copy(file, package_dir)
+from infra.vm.build_hcsshim import build_hcsshim
 
 
 @contextmanager

--- a/infra/vm/get_containerplat.py
+++ b/infra/vm/get_containerplat.py
@@ -1,27 +1,12 @@
-from contextlib import contextmanager
 import os
 import subprocess
 import json
-import tempfile
 from typing import Optional
-import zipfile
 import sys
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from infra.vm.build_hcsshim import build_hcsshim
-
-
-@contextmanager
-def update_package(package_path: str):
-    with tempfile.TemporaryDirectory() as unzipped_dir:
-        with zipfile.ZipFile(package_path, "a") as zip_ref:
-            zip_ref.extractall(unzipped_dir)
-            yield unzipped_dir
-            for root, dirs, files in os.walk(unzipped_dir):
-                for file in files:
-                    file_path = os.path.join(root, file)
-                    zip_ref.write(file_path, os.path.relpath(file_path, unzipped_dir))
 
 
 def get_containerplat(

--- a/infra/vm/get_containerplat.py
+++ b/infra/vm/get_containerplat.py
@@ -5,18 +5,19 @@ import shutil
 import subprocess
 import json
 import tempfile
+from typing import Optional
 import zipfile
 
 
 def build_hcsshim(
     package_path: str,
-    hcsshim_path: str = "git@github.com:microsoft/hcsshim.git",
+    hcsshim_url: str,
 ):
     with tempfile.TemporaryDirectory() as hcsshim_dir:
         with update_package(package_path) as package_dir:
             os.chdir(hcsshim_dir)
             subprocess.check_output(
-                f"git clone {hcsshim_path} github.com/Microsoft/hcsshim", shell=True
+                f"git clone {hcsshim_url} github.com/Microsoft/hcsshim", shell=True
             )
             os.chdir("github.com/Microsoft/hcsshim")
             os.environ["GOPATH"] = hcsshim_dir
@@ -51,7 +52,10 @@ def update_package(package_path: str):
                     zip_ref.write(file_path, os.path.relpath(file_path, unzipped_dir))
 
 
-def get_containerplat(directory_path: str):
+def get_containerplat(
+    directory_path: str,
+    hcsshim_url: Optional[str] = None,
+):
     subprocess.run(
         f'az artifacts universal download --organization "https://dev.azure.com/msazure/" --project "dcf1de98-e135-4121-8a6c-99b73705f581" --scope project --feed "ContainerPlat-Prod" --name "containerplat-confidential-aci" --version "0.1.3" --path "{directory_path}"',
         shell=True,
@@ -73,6 +77,8 @@ def get_containerplat(directory_path: str):
         shell=True,
     )
 
-    build_hcsshim(
-        package_path=f"{directory_path}/package.zip",
-    )
+    if hcsshim_url is not None:
+        build_hcsshim(
+            package_path=f"{directory_path}/package.zip",
+            hcsshim_url=hcsshim_url,
+        )

--- a/infra/vm/test_case.py
+++ b/infra/vm/test_case.py
@@ -70,7 +70,10 @@ def setUpVm(cls):
             image = f"{os.getenv('AZURE_REGISTRY_URL')}/{cls.manifest['testName']}/{container['image']}:{cls.image_tag}"
 
             with tempfile.TemporaryDirectory() as temp_dir:
-                get_containerplat(temp_dir)
+                get_containerplat(
+                    directory_path=temp_dir,
+                    hcsshim_url="git@github.com:microsoft/hcsshim.git",
+                )
 
                 deploy_containerplat(
                     ip_address=vm_ip,

--- a/infra/vm/test_case.py
+++ b/infra/vm/test_case.py
@@ -72,7 +72,9 @@ def setUpVm(cls):
             with tempfile.TemporaryDirectory() as temp_dir:
                 get_containerplat(
                     directory_path=temp_dir,
-                    hcsshim_url="git@github.com:microsoft/hcsshim.git",
+                    hcsshim_url=os.getenv(
+                        "HCSSHIM_URL", "git@github.com:microsoft/hcsshim.git"
+                    ),
                 )
 
                 deploy_containerplat(

--- a/infra/vm/update_containerplat.py
+++ b/infra/vm/update_containerplat.py
@@ -1,0 +1,16 @@
+from contextlib import contextmanager
+import os
+import tempfile
+import zipfile
+
+
+@contextmanager
+def update_package(package_path: str):
+    with tempfile.TemporaryDirectory() as unzipped_dir:
+        with zipfile.ZipFile(package_path, "a") as zip_ref:
+            zip_ref.extractall(unzipped_dir)
+            yield unzipped_dir
+            for root, dirs, files in os.walk(unzipped_dir):
+                for file in files:
+                    file_path = os.path.join(root, file)
+                    zip_ref.write(file_path, os.path.relpath(file_path, unzipped_dir))


### PR DESCRIPTION
Allow the user to build their own HCSShim and swap it out with the one contained in the ContainerPlatform package