### PR TITLE
fixing env var removal and unique id generation issues

### DIFF
--- a/.github/workflows/_aci_deploy.yml
+++ b/.github/workflows/_aci_deploy.yml
@@ -49,15 +49,15 @@ jobs:
             --tenant ${{ secrets.AZURE_SERVICE_PRINCIPAL_TENANT }}
       
       - name: Decrypt Manifest
+        id: decrypt-manifest
         run: |
           echo -e "${{ secrets.DECRYPTION_KEY }}" | gpg --import
           echo -e "${{ inputs.manifest }}" | gpg --decrypt > manifest.json
+          echo "test-name=$(cat manifest.json | jq -r '.testName')" >> $GITHUB_OUTPUT
 
       - name: Generate Per Location & Policy ID
         id: generate-id
-        run: |
-          testName=$(cat manifest.json | jq -r '.testName')
-          echo "cell-id=$(echo $testName-${{ inputs.location }}-${{ inputs.security-policy }}-${{ inputs.id }} | md5sum | sed 's/ //g' | sed 's/-//g')" >> $GITHUB_OUTPUT
+        run: echo "cell-id=$(echo ${{ steps.decrypt-manifest.outputs.test-name }}-${{ inputs.location }}-${{ inputs.security-policy }}-${{ inputs.id }} | md5sum | sed 's/ //g' | sed 's/-//g')" >> $GITHUB_OUTPUT
         
       - name: Generate ARM Template
         env:

--- a/infra/container/test_case.py
+++ b/infra/container/test_case.py
@@ -82,7 +82,6 @@ def setUpAci(cls):
 
 
 def tearDownAci(cls):
-    del os.environ["UNIQUE_ID"]
     if os.getenv("CLEANUP_ACI") not in ["0", "false", "False"]:
         with open(f"examples/{cls.test_name}/arm_template.json", "r") as f:
             delete_deployment(


### PR DESCRIPTION
Unique ID generation in the aci_deploy workflow didn't match the Unique ID generation in test_deployment workflow causing mismatching Unique IDs.

Additionally, creating a new test class for the same example created a new Unique ID because the tear down function was deleting the old Unique ID env var, which caused SKR tests to fail as the original Unique ID was also used to name the key that was being deployed.