### PR TITLE
update checkout action to v4 to remove warning

### DIFF
--- a/.github/workflows/_aci_deploy.yml
+++ b/.github/workflows/_aci_deploy.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: pip install -r requirements.txt

--- a/.github/workflows/_aci_remove.yml
+++ b/.github/workflows/_aci_remove.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Install dependencies
         run: pip install -r requirements.txt

--- a/.github/workflows/_resolve_manifest.yml
+++ b/.github/workflows/_resolve_manifest.yml
@@ -25,7 +25,7 @@ jobs:
       manifest: ${{ steps.resolve.outputs.manifest }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Import GPG Key
         run: |

--- a/.github/workflows/_test_deployment.yml
+++ b/.github/workflows/_test_deployment.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: pip install -r requirements.txt

--- a/.github/workflows/local_workflow.yml
+++ b/.github/workflows/local_workflow.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/push_example_image.yml
+++ b/.github/workflows/push_example_image.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: 4
 
       - name: Log in to Azure Container Registry
         uses: azure/docker-login@v1

--- a/.github/workflows/push_example_image.yml
+++ b/.github/workflows/push_example_image.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: 4
+        uses: actions/checkout@v4
 
       - name: Log in to Azure Container Registry
         uses: azure/docker-login@v1


### PR DESCRIPTION
Remove nodejs warning on checkout action by updating to v4