### PR TITLE
Use hard-pushed images to avoid docker io issues

### DIFF
--- a/examples/remote_images/docker-compose.yml
+++ b/examples/remote_images/docker-compose.yml
@@ -1,10 +1,10 @@
 version: '3'
 services:
   alpine:
-    image: alpine:latest
+    image: $REGISTRY/alpine:latest
   nginx:
-    image: nginx:stable
+    image: $REGISTRY/nginx:stable
   ubuntu:
-    image: ubuntu:latest
+    image: $REGISTRY/ubuntu:latest
   python:
-    image: python:latest
+    image: $REGISTRY/python:latest

--- a/examples/remote_images/remote_images.bicep
+++ b/examples/remote_images/remote_images.bicep
@@ -37,7 +37,7 @@ resource containerGroups 'Microsoft.ContainerInstance/containerGroups@2023-05-01
       {
         name: 'primary'
         properties: {
-          image: image
+          image: '${registry}/${image}'
           ports: []
           resources: {
             requests: {


### PR DESCRIPTION
Images are hard pushed until https://github.com/Azure/acr/issues/754 is fixed and we can setup an ACR cache