### PR TITLE
Bump c-aci-testing version

### DIFF
--- a/examples/attestation/get_attestation.py
+++ b/examples/attestation/get_attestation.py
@@ -106,7 +106,7 @@ REPORT_RSP_STRUCTURE = "".join(
         "I",  # Report Size
         "24x",  # -----
         SNP_REPORT_STRUCTURE,
-        "64x",  # padding to the size of SEV_SNP_REPORT_RSP_BUF_SZ
+        "2784x",  # padding to the size of SEV_SNP_REPORT_RSP_BUF_SZ
     ]
 )
 REPORT_RSP_SIZE = struct.calcsize(REPORT_RSP_STRUCTURE)
@@ -125,7 +125,7 @@ def get_attestation_report(report_data: bytes):
     )
 
     # Create blank MSG_REPORT_RSP to be populated by the IOCTL call
-    report_rsp = bytearray(4000)
+    report_rsp = bytearray(REPORT_RSP_SIZE)
 
     # Create the SEV-SNP Guest Request
     guest_req = bytearray(SNP_GUEST_REQ_SIZE)

--- a/examples/attestation/test.py
+++ b/examples/attestation/test.py
@@ -41,7 +41,6 @@ class AttestationTest(unittest.TestCase):
             target_path=os.path.realpath(os.path.dirname(__file__)),
             deployment_name=deployment_name,
             tag=id,
-            policy_type="allow_all",
             **vars(args),
         ) as deployment_ids:
             ip_address = aci_get_ips(

--- a/examples/attestation/test.py
+++ b/examples/attestation/test.py
@@ -35,14 +35,19 @@ class AttestationTest(unittest.TestCase):
         args, _ = parser.parse_known_args()
 
         id = str(uuid.uuid4())
+        deployment_name = f"attestation-{id}"
 
         with target_run_ctx(
             target_path=os.path.realpath(os.path.dirname(__file__)),
             deployment_name=f"attestation-{id}",
             tag=id,
+            policy_type="allow_all",
             **vars(args),
         ) as deployment_ids:
-            ip_address = aci_get_ips(ids=deployment_ids[0])
+            ip_address = aci_get_ips(
+                deployment_name=deployment_name,
+                **vars(args),
+            )[0]
 
             input_report_data = "Hello world!"
 

--- a/examples/attestation/test.py
+++ b/examples/attestation/test.py
@@ -39,7 +39,7 @@ class AttestationTest(unittest.TestCase):
 
         with target_run_ctx(
             target_path=os.path.realpath(os.path.dirname(__file__)),
-            deployment_name=f"attestation-{id}",
+            deployment_name=deployment_name,
             tag=id,
             policy_type="allow_all",
             **vars(args),

--- a/examples/python_server/test.py
+++ b/examples/python_server/test.py
@@ -30,14 +30,18 @@ class PythonServerTest(unittest.TestCase):
         args, _ = parser.parse_known_args()
 
         id = str(uuid.uuid4())
+        deployment_name = f"python-server-{id}"
 
         with target_run_ctx(
             target_path=os.path.realpath(os.path.dirname(__file__)),
-            deployment_name=f"python-server-{str(uuid.uuid4())}",
+            deployment_name=deployment_name,
             tag=id,
             **vars(args),
         ) as deployment_ids:
-            ip_address = aci_get_ips(ids=deployment_ids[0])
+            ip_address = aci_get_ips(
+                deployment_name=deployment_name,
+                **vars(args),
+            )[0]
             response = requests.get(f"http://{ip_address}:8000/hello")
             assert response.status_code == 200
             assert response.content.decode("utf-8") == "Hello, World!"

--- a/examples/sidecar/test.py
+++ b/examples/sidecar/test.py
@@ -30,14 +30,18 @@ class SidecarTest(unittest.TestCase):
         args, _ = parser.parse_known_args()
 
         id = str(uuid.uuid4())
+        deployment_name = f"sidecar-{id}"
 
         with target_run_ctx(
             target_path=os.path.realpath(os.path.dirname(__file__)),
-            deployment_name=f"sidecar-{id}",
+            deployment_name=deployment_name,
             tag=id,
             **vars(args),
         ) as deployment_ids:
-            ip_address = aci_get_ips(ids=deployment_ids[0])
+            ip_address = aci_get_ips(
+                deployment_name=deployment_name,
+                **vars(args),
+            )[0]
             response = requests.get(f"http://{ip_address}:8000/check_connection")
             assert response.status_code == 200
             assert response.content.decode("utf-8") == "True"

--- a/scripts/install-c-aci-testing.sh
+++ b/scripts/install-c-aci-testing.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version="1.0.3"
+version="1.0.14"
 gh release download $version -R microsoft/confidential-aci-testing
 pip install c_aci_testing*.tar.gz
 rm c_aci_testing*.tar.gz


### PR DESCRIPTION
Fixes a bug which failed to report failures.

This exposes that get_attestation.py hasn't been updated for 6.1 kernels, which this PR also fixes