### PR TITLE
Use ubuntu:22.04 for attestation example test workflow

### DIFF
--- a/.github/workflows/attestation.yml
+++ b/.github/workflows/attestation.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
We've seen consistent failures since roughly the time the runners testing the attestation example might have switched onto the newer ubuntu version, so pinning to the older version