### PR TITLE
Confidential_ACI_SCHEME.md: Update regex for tcbm to include A-F

### DIFF
--- a/docs/Confidential_ACI_SCHEME.md
+++ b/docs/Confidential_ACI_SCHEME.md
@@ -31,7 +31,7 @@ These are the AMD platform certificates, as per Trusted Hardware Identity Manage
     },
     "tcbm": {
       "type": "string",
-      "pattern": "^[0-9]+$"
+      "pattern": "^[0-9A-F]+$"
     },
     "certificateChain": {
       "type": "string"


### PR DESCRIPTION
```
Validating host-amd-cert-base64 against schema host-amd-cert.schema.json
ERROR: /security-context-2340184185/host-amd-cert-base64 does not conform to schema host-amd-cert.schema.json: 'DB18000000000004' does not match '^[0-9]+$'

Failed validating 'pattern' in schema['properties']['tcbm']:
    {'pattern': '^[0-9]+$', 'type': 'string'}

On instance['tcbm']:
    'DB18000000000004'
```

Real example:

```json
{
  "vcekCert": "-----BEGIN CERTIFICATE----- ... -----END CERTIFICATE-----\n",
  "tcbm": "DB18000000000004",
  "certificateChain": "-----BEGIN CERTIFICATE----- ... -----END CERTIFICATE-----\n-----BEGIN CERTIFICATE----- ... -----END CERTIFICATE-----\n",
  "cacheControl": "86400"
}
```